### PR TITLE
perf tests: Use quotes around variable expansion

### DIFF
--- a/tools/perf/tests/shell/test_task_analyzer.sh
+++ b/tools/perf/tests/shell/test_task_analyzer.sh
@@ -10,7 +10,7 @@ cleanup() {
   rm -f perf.data.old
   rm -f csv
   rm -f csvsummary
-  rm -rf $tmpdir
+  rm -rf "$tmpdir"
   trap - exit term int
 }
 
@@ -21,7 +21,7 @@ trap_cleanup() {
 trap trap_cleanup exit term int
 
 report() {
-	if [ $1 = 0 ]; then
+	if [ "$1" = 0 ]; then
 		echo "PASS: \"$2\""
 	else
 		echo "FAIL: \"$2\" Error message: \"$3\""
@@ -36,11 +36,11 @@ check_exec_0() {
 }
 
 find_str_or_fail() {
-	grep -q "$1" $2
-	if [ $? != 0 ]; then
-		report 1 $3 "Failed to find required string:'${1}'."
+	grep -q "$1" "$2"
+	if [ "$?" != 0 ]; then
+		report 1 "$3" "Failed to find required string:'${1}'."
 	else
-		report 0 $3
+		report 0 "$3"
 	fi
 }
 
@@ -52,86 +52,86 @@ prepare_perf_data() {
 # check standard inkvokation with no arguments
 test_basic() {
 	out="$tmpdir/perf.out"
-	perf script report task-analyzer > $out
+	perf script report task-analyzer > "$out"
 	check_exec_0 "perf"
-	find_str_or_fail "Comm" $out ${FUNCNAME[0]}
+	find_str_or_fail "Comm" "$out" "${FUNCNAME[0]}"
 }
 
 test_ns_rename(){
 	out="$tmpdir/perf.out"
-	perf script report task-analyzer --ns --rename-comms-by-tids 0:random > $out
+	perf script report task-analyzer --ns --rename-comms-by-tids 0:random > "$out"
 	check_exec_0 "perf"
-	find_str_or_fail "Comm" $out ${FUNCNAME[0]}
+	find_str_or_fail "Comm" "$out" "${FUNCNAME[0]}"
 }
 
 test_ms_filtertasks_highlight(){
 	out="$tmpdir/perf.out"
 	perf script report task-analyzer --ms --filter-tasks perf --highlight-tasks perf \
-	> $out
+	> "$out"
 	check_exec_0 "perf"
-	find_str_or_fail "Comm" $out ${FUNCNAME[0]}
+	find_str_or_fail "Comm" "$out" "${FUNCNAME[0]}"
 }
 
 test_extended_times_timelimit_limittasks() {
 	out="$tmpdir/perf.out"
 	perf script report task-analyzer --extended-times --time-limit :99999 \
-	--limit-to-tasks perf > $out
+	--limit-to-tasks perf > "$out"
 	check_exec_0 "perf"
-	find_str_or_fail "Out-Out" $out ${FUNCNAME[0]}
+	find_str_or_fail "Out-Out" "$out" "${FUNCNAME[0]}"
 }
 
 test_summary() {
 	out="$tmpdir/perf.out"
-	perf script report task-analyzer --summary > $out
+	perf script report task-analyzer --summary > "$out"
 	check_exec_0 "perf"
-	find_str_or_fail "Summary" $out ${FUNCNAME[0]}
+	find_str_or_fail "Summary" "$out" "${FUNCNAME[0]}"
 }
 
 test_summaryextended() {
 	out="$tmpdir/perf.out"
-	perf script report task-analyzer --summary-extended > $out
+	perf script report task-analyzer --summary-extended > "$out"
 	check_exec_0 "perf"
-	find_str_or_fail "Inter Task Times" $out ${FUNCNAME[0]}
+	find_str_or_fail "Inter Task Times" "$out" "${FUNCNAME[0]}"
 }
 
 test_summaryonly() {
 	out="$tmpdir/perf.out"
-	perf script report task-analyzer --summary-only > $out
+	perf script report task-analyzer --summary-only > "$out"
 	check_exec_0 "perf"
-	find_str_or_fail "Summary" $out ${FUNCNAME[0]}
+	find_str_or_fail "Summary" "$out" "${FUNCNAME[0]}"
 }
 
 test_extended_times_summary_ns() {
 	out="$tmpdir/perf.out"
-	perf script report task-analyzer --extended-times --summary --ns > $out
+	perf script report task-analyzer --extended-times --summary --ns > "$out"
 	check_exec_0 "perf"
-	find_str_or_fail "Out-Out" $out ${FUNCNAME[0]}
-	find_str_or_fail "Summary" $out ${FUNCNAME[0]}
+	find_str_or_fail "Out-Out" "$out" "${FUNCNAME[0]}"
+	find_str_or_fail "Summary" "$out" "${FUNCNAME[0]}"
 }
 
 test_csv() {
 	perf script report task-analyzer --csv csv > /dev/null
 	check_exec_0 "perf"
-	find_str_or_fail "Comm;" csv ${FUNCNAME[0]}
+	find_str_or_fail "Comm;" csv "${FUNCNAME[0]}"
 }
 
 test_csv_extended_times() {
 	perf script report task-analyzer --csv csv --extended-times > /dev/null
 	check_exec_0 "perf"
-	find_str_or_fail "Out-Out;" csv ${FUNCNAME[0]}
+	find_str_or_fail "Out-Out;" csv "${FUNCNAME[0]}"
 }
 
 test_csvsummary() {
 	perf script report task-analyzer --csv-summary csvsummary > /dev/null
 	check_exec_0 "perf"
-	find_str_or_fail "Comm;" csvsummary ${FUNCNAME[0]}
+	find_str_or_fail "Comm;" csvsummary "${FUNCNAME[0]}"
 }
 
 test_csvsummary_extended() {
 	perf script report task-analyzer --csv-summary csvsummary --summary-extended \
 	>/dev/null
 	check_exec_0 "perf"
-	find_str_or_fail "Out-Out;" csvsummary ${FUNCNAME[0]}
+	find_str_or_fail "Out-Out;" csvsummary "${FUNCNAME[0]}"
 }
 
 prepare_perf_data


### PR DESCRIPTION
Fixes SC2086: Double quote to prevent globbing and word splitting warnings in shell-check.

**Before Patch:**

```
❯ shellcheck test_task_analyzer.sh                                                                ─╯

In test_task_analyzer.sh line 13:
  rm -rf $tmpdir
         ^-----^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 24:
	if [ $1 = 0 ]; then
             ^-- SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 33:
	if [ $? != 0 ]; then
             ^-- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In test_task_analyzer.sh line 34:
		report 1 "invokation of ${$1} command failed"
                                        ^---^ SC2082: To expand via indirection, use arrays, ${!name} or (for sh only) eval.


In test_task_analyzer.sh line 39:
	grep -q "$1" $2
                     ^-- SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 40:
	if [ $? != 0 ]; then
             ^-- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In test_task_analyzer.sh line 41:
		report 1 $3 "Failed to find required string:'${1}'."
                         ^-- SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 43:
		report 0 $3
                         ^-- SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 55:
	perf script report task-analyzer > $out
                                           ^--^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 57:
	find_str_or_fail "Comm" $out ${FUNCNAME[0]}
                                ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                     ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 62:
	perf script report task-analyzer --ns --rename-comms-by-tids 0:random > $out
                                                                                ^--^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 64:
	find_str_or_fail "Comm" $out ${FUNCNAME[0]}
                                ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                     ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 70:
	> $out
          ^--^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 72:
	find_str_or_fail "Comm" $out ${FUNCNAME[0]}
                                ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                     ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 78:
	--limit-to-tasks perf > $out
                                ^--^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 80:
	find_str_or_fail "Out-Out" $out ${FUNCNAME[0]}
                                   ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                        ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 85:
	perf script report task-analyzer --summary > $out
                                                     ^--^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 87:
	find_str_or_fail "Summary" $out ${FUNCNAME[0]}
                                   ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                        ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 92:
	perf script report task-analyzer --summary-extended > $out
                                                              ^--^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 94:
	find_str_or_fail "Inter Task Times" $out ${FUNCNAME[0]}
                                            ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                                 ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 99:
	perf script report task-analyzer --summary-only > $out
                                                          ^--^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 101:
	find_str_or_fail "Summary" $out ${FUNCNAME[0]}
                                   ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                        ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 106:
	perf script report task-analyzer --extended-times --summary --ns > $out
                                                                           ^--^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 108:
	find_str_or_fail "Out-Out" $out ${FUNCNAME[0]}
                                   ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                        ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 109:
	find_str_or_fail "Summary" $out ${FUNCNAME[0]}
                                   ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                        ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 115:
	find_str_or_fail "Comm;" csv ${FUNCNAME[0]}
                                     ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 121:
	find_str_or_fail "Out-Out;" csv ${FUNCNAME[0]}
                                        ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 127:
	find_str_or_fail "Comm;" csvsummary ${FUNCNAME[0]}
                                            ^------------^ SC2086: Double quote to prevent globbing and word splitting.


In test_task_analyzer.sh line 134:
	find_str_or_fail "Out-Out;" csvsummary ${FUNCNAME[0]}
                                               ^------------^ SC2086: Double quote to prevent globbing and word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2082 -- To expand via indirection, use ar...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2181 -- Check exit code directly with e.g...                 59ms
```

**After Patch:**

```
❯ shellcheck ./tests/shell/test_task_analyzer.sh                                             ─╯

In ./tests/shell/test_task_analyzer.sh line 33:
	if [ $? != 0 ]; then
             ^-- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In ./tests/shell/test_task_analyzer.sh line 34:
		report 1 "invokation of ${$1} command failed"
                                        ^---^ SC2082: To expand via indirection, use arrays, ${!name} or (for sh only) eval.


In ./tests/shell/test_task_analyzer.sh line 40:
	if [ "$?" != 0 ]; then
             ^--^ SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.

For more information:
  https://www.shellcheck.net/wiki/SC2082 -- To expand via indirection, use ar...
  https://www.shellcheck.net/wiki/SC2181 -- Check exit code directly with e.g...            60ms

```

**Perf test:**

```
root:/home/abd/perf/linux/tools/perf# ./perf test task-analyzer
104: perf script task-analyzer tests                                 : Ok
```


