### PR TITLE
perf test : fixing signal names in test_arm_callgraph_fp

### DIFF
--- a/tools/perf/tests/shell/test_arm_callgraph_fp.sh
+++ b/tools/perf/tests/shell/test_arm_callgraph_fp.sh
@@ -9,13 +9,13 @@ TEST_PROGRAM="perf test -w leafloop"
 
 cleanup_files()
 {
-	rm -f $PERF_DATA
+	rm -f "$PERF_DATA"
 }
 
-trap cleanup_files exit term int
+trap cleanup_files EXIT TERM INT
 
 # Add a 1 second delay to skip samples that are not in the leaf() function
-perf record -o $PERF_DATA --call-graph fp -e cycles//u -D 1000 --user-callchains -- $TEST_PROGRAM 2> /dev/null &
+perf record -o "$PERF_DATA" --call-graph fp -e cycles//u -D 1000 --user-callchains -- "$TEST_PROGRAM" 2> /dev/null &
 PID=$!
 
 echo " + Recording (PID=$PID)..."


### PR DESCRIPTION
Shellcheck throws error "POSIX sh, using lower/mixed case for signal names is undefined" so to fix this, converting signal names to upper case.
Also, When command expansions are unquoted, word splitting and globbing will occur. To solve this, quote the command substitution ex:$(fix) to "$(fix)"


Signed-off-by: Spoorthy S<spoorts2@in.ibm.com>