### PR TITLE
tools/perf/tests: fix shellcheck warning for stat+json_output

### DIFF
--- a/tools/perf/tests/shell/stat+json_output.sh
+++ b/tools/perf/tests/shell/stat+json_output.sh
@@ -26,7 +26,7 @@ fi
 # Return true if perf_event_paranoid is > $1 and not running as root.
 function ParanoidAndNotRoot()
 {
-	 [ $(id -u) != 0 ] && [ $(cat /proc/sys/kernel/perf_event_paranoid) -gt $1 ]
+	 [ "$(id -u)" != 0 ] && [ "$(cat /proc/sys/kernel/perf_event_paranoid)" -gt $1 ]
 }
 
 check_no_args()


### PR DESCRIPTION
fix following shellcheck warning for perf stat+json_output test

```
[ $(id -u) != 0 ] && [ $(cat /proc/sys/kernel/perf_event_paranoid) -gt $1 ]
  ^------^ SC2046 (warning): Quote this to prevent word splitting.
                       ^-- SC2046 (warning): Quote this to prevent word
                                             splitting. 
```

tested on a powerpc box, after changes also test works fine
 88: perf stat JSON output linter                                    : Ok

Signed-off-by: Disha Goel <disgoel@linux.ibm.com>