### PR TITLE
perf test: various shellcheck failures are addressed for stat+shadow_stat.sh

### DIFF
--- a/tools/perf/tests/shell/stat+shadow_stat.sh
+++ b/tools/perf/tests/shell/stat+shadow_stat.sh
@@ -14,7 +14,7 @@ test_global_aggr()
 {
 	perf stat -a --no-big-num -e cycles,instructions sleep 1  2>&1 | \
 	grep -e cycles -e instructions | \
-	while read num evt hash ipc rest
+	while read -r num evt ipc rest
 	do
 		# skip not counted events
 		if [ "$num" = "<not" ]; then
@@ -33,7 +33,7 @@ test_global_aggr()
 		fi
 
 		# use printf for rounding and a leading zero
-		res=`printf "%.2f" $(echo "scale=6; $num / $cyc" | bc -q)`
+		res=$(printf "%.2f" "$(echo "scale=6; $num / $cyc" | bc -q)")
 		if [ "$ipc" != "$res" ]; then
 			echo "IPC is different: $res != $ipc  ($num / $cyc)"
 			exit 1
@@ -45,7 +45,7 @@ test_no_aggr()
 {
 	perf stat -a -A --no-big-num -e cycles,instructions sleep 1  2>&1 | \
 	grep ^CPU | \
-	while read cpu num evt hash ipc rest
+	while read -r cpu num evt ipc rest
 	do
 		# skip not counted events
 		if [ "$num" = "<not" ]; then
@@ -58,7 +58,7 @@ test_no_aggr()
 			continue
 		fi
 
-		cyc=${results##* $cpu:}
+		cyc=${results##* "$cpu":}
 		cyc=${cyc%% *}
 
 		# skip if no cycles
@@ -67,7 +67,7 @@ test_no_aggr()
 		fi
 
 		# use printf for rounding and a leading zero
-		res=`printf "%.2f" $(echo "scale=6; $num / $cyc" | bc -q)`
+		res=$(printf "%.2f" "$(echo "scale=6; $num / $cyc" | bc -q)")
 		if [ "$ipc" != "$res" ]; then
 			echo "IPC is different for $cpu: $res != $ipc  ($num / $cyc)"
 			exit 1


### PR DESCRIPTION
1. Read command should have -r option given then backslash does not act as an escape character.
2. Expansions inside `${..} `need to be quoted separately,  or it will match as a pattern. The quotes around the outer parameter expansion does not protect against this.ex:"${2#$1}" to "${2#"$1"}"
3. Variables not used for anything are often associated with bugs, so ShellCheck warns about them. Hence removing the variable "hash" which is not used anywhere in script

Signed-off-by: Spoorthy S<spoorts2@in.ibm.com>