### PR TITLE
tools/perf/tests: Fix shellcheck warnings for stat+csv_output

### DIFF
--- a/tools/perf/tests/shell/stat+csv_output.sh
+++ b/tools/perf/tests/shell/stat+csv_output.sh
@@ -20,7 +20,7 @@ function commachecker()
 	;; "--interval")	exp=7
 	;; "--per-thread")	exp=7
 	;; "--system-wide-no-aggr")	exp=7
-				[ $(uname -m) = "s390x" ] && exp='^[6-7]$'
+				[ "$(uname -m)" = "s390x" ] && exp='^[6-7]$'
 	;; "--per-core")	exp=8
 	;; "--per-socket")	exp=8
 	;; "--per-node")	exp=8
@@ -48,7 +48,7 @@ function commachecker()
 # Return true if perf_event_paranoid is > $1 and not running as root.
 function ParanoidAndNotRoot()
 {
-	 [ $(id -u) != 0 ] && [ $(cat /proc/sys/kernel/perf_event_paranoid) -gt $1 ]
+	 [ "$(id -u)" != 0 ] && [ "$(cat /proc/sys/kernel/perf_event_paranoid)" -gt $1 ]
 }
 
 check_no_args()


### PR DESCRIPTION
This patch fixes the shellcheck warnings for stat+csv_output

Without patch:
```
$ shellcheck -S warning stat+csv_output.sh
In stat+csv_output.sh line 23:
                                [ $(uname -m) = "s390x" ] && exp='^[6-7]$'
                                  ^---------^ SC2046: Quote this to prevent word splitting.
In stat+csv_output.sh line 51:
         [ $(id -u) != 0 ] && [ $(cat /proc/sys/kernel/perf_event_paranoid) -gt $1 ]
           ^------^ SC2046: Quote this to prevent word splitting.
                                ^-- SC2046: Quote this to prevent word splitting.
```

With patch:
```
$ shellcheck -S warning tests/shell/stat+csv_output.sh 
$ ./perf test "stat CSV output linter"
 96: perf stat CSV output linter                                     : Ok
```
