### PR TITLE
tools/perf/tests: Fix shellcheck warnings for trace+probe_vfs_getname.sh

### DIFF
--- a/tools/perf/tests/shell/trace+probe_vfs_getname.sh
+++ b/tools/perf/tests/shell/trace+probe_vfs_getname.sh
@@ -10,15 +10,15 @@
 # SPDX-License-Identifier: GPL-2.0
 # Arnaldo Carvalho de Melo <acme@kernel.org>, 2017
 
-. $(dirname $0)/lib/probe.sh
+. "$(dirname $0)"/lib/probe.sh
 
 skip_if_no_perf_probe || exit 2
 skip_if_no_perf_trace || exit 2
 
-. $(dirname $0)/lib/probe_vfs_getname.sh
+. "$(dirname $0)"/lib/probe_vfs_getname.sh
 
 trace_open_vfs_getname() {
-	evts=$(echo $(perf list syscalls:sys_enter_open* 2>/dev/null | grep -E 'open(at)? ' | sed -r 's/.*sys_enter_([a-z]+) +\[.*$/\1/') | sed 's/ /,/')
+	evts=$(echo "$(perf list syscalls:sys_enter_open* 2>/dev/null | grep -E 'open(at)? ' | sed -r 's/.*sys_enter_([a-z]+) +\[.*$/\1/')" | sed 's/ /,/')
 	perf trace -e $evts touch $file 2>&1 | \
 	grep -E " +[0-9]+\.[0-9]+ +\( +[0-9]+\.[0-9]+ ms\): +touch\/[0-9]+ open(at)?\((dfd: +CWD, +)?filename: +${file}, +flags: CREAT\|NOCTTY\|NONBLOCK\|WRONLY, +mode: +IRUGO\|IWUGO\) += +[0-9]+$"
 }


### PR DESCRIPTION
This patch fixes the "Quote this to prevent word splitting." shellcheck warnings
Without patch:
```
 # shellcheck -S warning trace+probe_vfs_getname.sh 
 
In trace+probe_vfs_getname.sh line 13:
. $(dirname $0)/lib/probe.sh
  ^-----------^ SC2046 (warning): Quote this to prevent word splitting.

In trace+probe_vfs_getname.sh line 18:
. $(dirname $0)/lib/probe_vfs_getname.sh
  ^-----------^ SC2046 (warning): Quote this to prevent word splitting.

In trace+probe_vfs_getname.sh line 21:
	evts=$(echo $(perf list syscalls:sys_enter_open* 2>/dev/null | grep -E 'open(at)? ' | sed -r 's/.*sys_enter_([a-z]+) +\[.*$/\1/') | sed 's/ /,/')
                    ^-- SC2046 (warning): Quote this to prevent word splitting.
  # perf test "trace + vfs_getname"
100: Check open filename arg using perf trace + vfs_getname          : Skip
```
Tested on PowerPc.

With patch:
```
# shellcheck -S warning trace+probe_vfs_getname.sh 
# perf test "trace + vfs_getname"
100: Check open filename arg using perf trace + vfs_getname          : Skip
```

