### PR TITLE
tools/perf/tests/shell/stat_all_metrics: Fix shellcheck warning SC207…

### DIFF
--- a/tools/perf/tests/shell/stat_all_metrics.sh
+++ b/tools/perf/tests/shell/stat_all_metrics.sh
@@ -6,20 +6,20 @@ err=0
 for m in $(perf list --raw-dump metrics); do
   echo "Testing $m"
   result=$(perf stat -M "$m" true 2>&1)
-  if [[ "$result" =~ "${m:0:50}" ]] || [[ "$result" =~ "<not supported>" ]]
+  if [[ "$result" =~ ${m:0:50} ]] || [[ "$result" =~ "<not supported>" ]]
   then
     continue
   fi
   # Failed so try system wide.
   result=$(perf stat -M "$m" -a sleep 0.01 2>&1)
-  if [[ "$result" =~ "${m:0:50}" ]]
+  if [[ "$result" =~ ${m:0:50} ]]
   then
     continue
   fi
   # Failed again, possibly the workload was too small so retry with something
   # longer.
   result=$(perf stat -M "$m" perf bench internals synthesize 2>&1)
-  if [[ "$result" =~ "${m:0:50}" ]]
+  if [[ "$result" =~ ${m:0:50} ]]
   then
     continue
   fi


### PR DESCRIPTION
…6 in stat_all_metrics.sh

Fixed shellcheck warning SC2076 in stat_all_metrics.sh.

Before the patch:
shell$ shellcheck stat_all_metrics.sh

In stat_all_metrics.sh line 9:
  if [[ "$result" =~ "${m:0:50}" ]] || [[ "$result" =~ "<not supported>" ]]
                     ^---------^ SC2076: Don't quote right-hand side of =~, it'll match literally rather than as a regex.

In stat_all_metrics.sh line 15:
  if [[ "$result" =~ "${m:0:50}" ]]
                     ^---------^ SC2076: Don't quote right-hand side of =~, it'll match literally rather than as a regex.

In stat_all_metrics.sh line 22:
  if [[ "$result" =~ "${m:0:50}" ]]
                     ^---------^ SC2076: Don't quote right-hand side of =~, it'll match literally rather than as a regex.

For more information:
  https://www.shellcheck.net/wiki/SC2076 -- Don't quote right-hand side of =~...

After the patch:
shell$ shellcheck stat_all_metrics.sh
shell$